### PR TITLE
Added /oem partition

### DIFF
--- a/ramdisk/fstab.front
+++ b/ramdisk/fstab.front
@@ -11,6 +11,7 @@
 /dev/block/platform/omap/omap_hsmmc.1/by-name/userdata    /data        ext4  nosuid,nodev,noatime,noauto_da_alloc,discard,journal_async_commit,errors=panic    wait,check,encryptable=footer,length=-16384
 /dev/block/platform/omap/omap_hsmmc.1/by-name/userdata    /data        f2fs  rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                   wait,check,encryptable=footer,length=-16384
 /dev/block/platform/omap/omap_hsmmc.1/by-name/cust        /cust        ext4  nosuid,nodev,noatime,noauto_da_alloc,discard,journal_async_commit,errors=panic    wait,check
+/dev/block/platform/omap/omap_hsmmc.1/by-name/cust        /oem         ext4  nosuid,nodev,noatime,noauto_da_alloc,discard,journal_async_commit,errors=panic    wait,check
 /dev/block/platform/omap/omap_hsmmc.1/by-name/misc        /misc        emmc  defaults  defaults
 /dev/block/platform/omap/omap_hsmmc.1/by-name/boot        /boot        emmc  defaults  defaults
 /dev/block/platform/omap/omap_hsmmc.1/by-name/recovery    /recovery    emmc  defaults  defaults


### PR DESCRIPTION
Mount /cust also as /oem. This is required to add a custom boot animation (at /oem/media) in Lollipop.